### PR TITLE
Add Key Management service docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,10 @@ A downloadable version of the documentation is include with in the release zip, 
 
 __ https://github.com/oracle/oci-python-sdk/releases
 
+The downloadable version of the documentation does not contain the Key Management service API documentation.  This will be fixed with the next release.  For the Key Management service API, please refer to the online API documentation `here`__.
+
+__ https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/api/index.html
+
 ====
 Help
 ====

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -234,6 +234,31 @@ Identity
     :noindex:
 
 
+==============
+Key Management
+==============
+
+--------
+ Client
+--------
+
+.. autoclass:: oci.key_management.key_management_client.KeyManagementClient
+    :members:
+    :noindex:
+
+--------
+ Models
+--------
+
+.. automodule:: oci.key_management.models
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :imported-members:
+    :inherited-members:
+    :noindex:
+
+
 =============
 Load Balancer
 =============

--- a/docs/api/key_management.rst
+++ b/docs/api/key_management.rst
@@ -1,0 +1,38 @@
+Key Management 
+==============
+
+.. autosummary::
+    :toctree: key_management/client
+    :nosignatures:
+    :template: autosummary/service_client.rst
+
+    oci.key_management.KeyManagementClient
+    oci.key_management.KeyManagementClientCompositeOperations
+
+--------
+ Models
+--------
+
+.. autosummary::
+    :toctree: key_management/models
+    :nosignatures:
+    :template: autosummary/model_class.rst
+
+    oci.key_management.models.CreateKeyDetails
+    oci.key_management.models.CreateVaultDetails
+    oci.key_management.models.DecryptDataDetails
+    oci.key_management.models.DecryptedData
+    oci.key_management.models.EncryptDataDetails
+    oci.key_management.models.EncryptedData
+    oci.key_management.models.GenerateKeyDetails
+    oci.key_management.models.GeneratedKey
+    oci.key_management.models.Key
+    oci.key_management.models.KeyShape
+    oci.key_management.models.KeySummary
+    oci.key_management.models.KeyVersion
+    oci.key_management.models.KeyVersionSummary
+    oci.key_management.models.ScheduleVaultDeletionDetails
+    oci.key_management.models.UpdateKeyDetails
+    oci.key_management.models.UpdateVaultDetails
+    oci.key_management.models.Vault
+    oci.key_management.models.VaultSummary

--- a/docs/api/landing.rst
+++ b/docs/api/landing.rst
@@ -13,6 +13,7 @@ API Reference
 * :doc:`Email  <email>`
 * :doc:`File Storage  <file_storage>`
 * :doc:`Identity  <identity>`
+* :doc:`Key Management  <key_management>`
 * :doc:`Load Balancer  <load_balancer>`
 * :doc:`Object Storage  <object_storage>`
 * :doc:`Resource Search  <resource_search>`
@@ -45,6 +46,7 @@ API Reference
     email
     file_storage
     identity
+    key_management
     load_balancer
     object_storage
     resource_search


### PR DESCRIPTION
The Key Management service docs were missed in the 2.0.4 release.
This commit add the docs for ReadtheDocs as stop-gab until the
next release.