### PR TITLE
Add path to readthedocs python installation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,6 +14,7 @@ python:
     install:
         - requirements: readthedocs/requirements.txt
         - method: pip
+          path: .
    
 # Just the HTML and indexing
 formats: []


### PR DESCRIPTION
Error states "Problem in your project's configuration. Invalid "python.install.1": .readthedocs.yml: "path" or "requirements" key is required"
However, it looks like both are required.